### PR TITLE
Fix mobile zoom bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <html lang="en">
     <head>
       <title>Barrett Arbour</title>
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <meta name="viewport" content="width=device-width">
       <link href="https://fonts.googleapis.com/css?family=Lato&display=swap" rel="stylesheet">
       <link href="https://fonts.googleapis.com/css?family=Playfair+Display SC&display=swap" rel="stylesheet">
       <link rel="icon" href="images/logo.png">


### PR DESCRIPTION
Removed initial-scale=1. Apparently the issue is with elements that are styled to have 100% width in conjunction with initial-scale=1 (https://stackoverflow.com/a/57374495).